### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl" : "6.*",
   "name" : "JSON::WebToken",
+  "license" : "GPL-1.0+ OR Artistic-1.0-Perl",
   "version" : "0.0.1",
   "description" : "JSON::WebToken is a JSON Web Token (JWT) implementation for Perl6",
   "authors" : [ "James Albert" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license